### PR TITLE
Have Livereload watch for all .html files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -187,7 +187,7 @@ module.exports = function (grunt) {
           livereload: LIVERELOAD_PORT
         },
         files: [
-          '<%= project.app %>/index.html',
+          '<%= project.app %>/*.html',
           '<%= project.assets %>/css/*.css',
           '<%= project.assets %>/js/{,*/}*.js',
           '<%= project.assets %>/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'


### PR DESCRIPTION
Livereload will look out for `index.html` as usual, but now can also look out for something like `other.html` as well.
