### PR TITLE
separated connect and livereload tasks in devDependencies and Gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -204,7 +204,8 @@ module.exports = function (grunt) {
     'sass:dev',
     'jshint',
     'concat:dev',
-    'connect:livereload',
+    'connect',
+    'livereload',
     'open',
     'watch'
   ]);

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "grunt-contrib-sass": "~0.5.0",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-connect": "~0.3.0",
+    "grunt-contrib-livereload": "~0.1.2",
     "grunt-contrib-jshint": "~0.4.3",
     "grunt-contrib-watch": "~0.4.4",
-    "connect-livereload": "~0.2.0",
     "grunt-open": "~0.2.0",
     "matchdep": "~0.1.2"
   }


### PR DESCRIPTION
For some reason connect-livereload wasn't working. I'm on Windows 7. I kept getting a "connect:livereload task does not exist" warning. 

Installing grunt-contrib-livereload instead of connect-livereload in the devDependencies of the package.json file, and then separating the "connect" and "livereload" tasks in the Gruntfile solved this issue.
