### PR TITLE
Autoprefixer - Pull request

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,6 +131,18 @@ module.exports = function (grunt) {
     },
 
     /**
+     * Clean files and folders
+     * https://github.com/gruntjs/grunt-contrib-clean
+     * Remove files by demand
+     */
+    clean: {
+      dist: [
+        '<%= project.app %>/css/style.unprefixed.css',
+        '<%= project.app %>/css/style.prefixed.css'
+      ]
+    },
+
+    /**
      * Compile Sass/SCSS files
      * https://github.com/gruntjs/grunt-contrib-sass
      * Compiles all Sass/SCSS files and appends project banner
@@ -142,16 +154,57 @@ module.exports = function (grunt) {
           banner: '<%= tag.banner %>'
         },
         files: {
-          '<%= project.app %>/css/style.min.css': '<%= project.css %>'
+          '<%= project.app %>/css/style.unprefixed.css': '<%= project.css %>'
         }
       },
       dist: {
         options: {
-          style: 'compressed',
+          style: 'expanded'
+        },
+        files: {
+          '<%= project.app %>/css/style.unprefixed.css': '<%= project.css %>'
+        }
+      }
+    },
+
+    /**
+     * Adds vendor prefixes if need automatcily
+     * https://github.com/nDmitry/grunt-autoprefixer
+     */
+    autoprefixer: {
+      options: {
+        browsers: [
+          'last 2 version',
+          // 'safari 6',
+          // 'ie 9',
+          // 'opera 12.1',
+          // 'ios 6',
+          // 'android 4'
+        ]
+      },
+      dev: {
+        files: {
+          '<%= project.app %>/css/style.min.css': ['<%= project.app %>/css/style.unprefixed.css']
+        }
+      },
+      dist: {
+        files: {
+          '<%= project.app %>/css/style.prefixed.css': ['<%= project.app %>/css/style.unprefixed.css']
+        }
+      }
+    },
+
+    /**
+     * Does CSS minification
+     * https://github.com/gruntjs/grunt-contrib-cssmin
+     */
+    cssmin: {
+      dist: {
+        options: {
           banner: '<%= tag.banner %>'
         },
         files: {
-          '<%= project.app %>/css/style.min.css': '<%= project.css %>'
+          '<%= project.app %>/css/style.min.css': ['<%= project.app %>/css/style.prefixed.css']
         }
       }
     },
@@ -179,7 +232,10 @@ module.exports = function (grunt) {
       },
       sass: {
         files: '<%= project.src %>/scss/{,*/}*.{scss,sass}',
-        tasks: ['sass:dev']
+        tasks: ['sass:dev', 'autoprefixer:dev']
+      },
+      css: {
+        files: '<%= project.app %>/css/*.css'
       },
       livereload: {
         options: {
@@ -193,6 +249,7 @@ module.exports = function (grunt) {
         ]
       }
     }
+
   });
 
   /**
@@ -201,6 +258,7 @@ module.exports = function (grunt) {
    */
   grunt.registerTask('default', [
     'sass:dev',
+    'autoprefixer:dev',
     'jshint',
     'concat:dev',
     'connect:livereload',
@@ -215,6 +273,9 @@ module.exports = function (grunt) {
    */
   grunt.registerTask('build', [
     'sass:dist',
+    'autoprefixer:dist',
+    'cssmin:dist',
+    'clean:dist',
     'jshint',
     'uglify'
   ]);

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "FireShell",
   "title": "Fiercely quick and opinionated front-ends",
-  "url" : "http://getfireshell.com",
+  "url": "http://getfireshell.com",
   "author": "Todd Motto",
   "copyright": "2013",
   "version": "1.0.0",
   "license": "MIT",
-  "repository" : {
-    "type" : "git",
-    "url" : "http://github.com/toddmotto/fireshell.git"
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/toddmotto/fireshell.git"
   },
   "devDependencies": {
     "grunt": "~0.4.1",
@@ -17,8 +17,10 @@
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-connect": "~0.3.0",
     "grunt-contrib-jshint": "~0.4.3",
-    "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-watch": "~0.4.4",
+    "grunt-autoprefixer": "~0.3.0",
+    "grunt-contrib-cssmin": "~0.6.2",
+    "grunt-contrib-clean": "~0.5.0",
     "connect-livereload": "~0.2.0",
     "grunt-open": "~0.2.0",
     "matchdep": "~0.1.2"

--- a/src/scss/mixins/_vendor.scss
+++ b/src/scss/mixins/_vendor.scss
@@ -1,7 +1,0 @@
-@mixin vendor ($property, $value...) {
-    -webkit-#{$property}:$value;
-    -moz-#{$property}:$value;
-    -ms-#{$property}:$value;
-    -o-#{$property}:$value;
-    #{$property}:$value;
-}

--- a/src/scss/modules/_clearfix.scss
+++ b/src/scss/modules/_clearfix.scss
@@ -1,14 +1,15 @@
 %clear {
-  content:' ';
-  display:table;
+  content: ' ';
+  display: table;
 }
+
 .clear {
-  *zoom:1;
   &:before {
     @extend %clear;
   }
+
   &:after {
     @extend %clear;
-    clear:both;
+    clear: both;
   }
 }

--- a/src/scss/modules/_defaults.scss
+++ b/src/scss/modules/_defaults.scss
@@ -2,11 +2,13 @@
   -webkit-font-smoothing:antialiased;
   font-smoothing:antialiased;
   text-rendering:optimizeLegibility;
-  @include vendor(box-sizing, border-box);
+  box-sizing: border-box;
 }
+
 html {
   font-size:62.5%;
 }
+
 body {
   font:300 13px/1.6 'Helvetica Neue', Helvetica, Arial;
   background:#fff;

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -2,7 +2,6 @@
 // SCSS MIXINS
 //----------------------------------*/
 
-@import 'mixins/_vendor.scss';
 @import 'mixins/_position.scss';
 
 //----------------------------------*\


### PR DESCRIPTION
adding the grunt task autoprefixer. and all the necessary around it
## pakages.json

these packages added:
- grunt-autoprefixer: for auto vendor prefix adding
- grunt-contrib-cssmin: because autoprefixer doesn't minify CSS (need
  to check this)
- grunt-contrib-clean: remove unnecessary files (CSS files before
  minify)
## Gruntfile.js
- adding `clean` task to remove unminify files
- chainging `sass` task to support autoprefiexer
- adding `autoprefixer` task
- adding `cssmin` task to compress css file after autoprefixer task on
  `dist` tasks
- adding to `watch` task autoprefixer task
- changing `grunt.registerTask` to support all needed to `autoprefixer`
## scss
- removed the _vendor.scss file because it isn't needed any more
- _defaults.scss: doesn't use vendor mixin, because it's not needed
- style.scss: import of _vendor.scss removed due removing of the file
