### PR TITLE
Linked up tags to headings and added issue numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # FireShell Changelog
 
-## 1.1.0 (21 September, 2013)
+## [1.1.0](https://github.com/toddmotto/fireshell/releases/tag/v1.1.0) (21 September, 2013)
 
 * Add Roadmap and Contributors to `README.md`
-* Move `img`, `css`, `js`, `fonts` folders into new `assets` for tidier scaffolding
-* Add `grunt-dev.bat` and `grunt-build.bat` for Windows support double-click commands
+* Move `img`, `css`, `js`, `fonts` folders into new `assets` for tidier scaffolding ([#8](https://github.com/toddmotto/fireshell/pull/8))
+* Add `grunt-dev.bat` and `grunt-build.bat` for Windows support double-click commands ([#7](https://github.com/toddmotto/fireshell/pull/7))
 * Small `Gruntfile.js` tweaks for `assets` object
 
-## 1.0.0 (15 September, 2013)
+## [1.0.0](https://github.com/toddmotto/fireshell/releases/tag/v1.0.0) (15 September, 2013)
 
 * Initial commit


### PR DESCRIPTION
Each version now has a link to its release information. Each item that has a issue associated with it now has a link to that issue.

before:
## 1.1.0 (21 September, 2013)
- Add Roadmap and Contributors to `README.md`
- Move `img`, `css`, `js`, `fonts` folders into new `assets` for tidier scaffolding
- Add `grunt-dev.bat` and `grunt-build.bat` for Windows support double-click commands
- Small `Gruntfile.js` tweaks for `assets` object

after:
## [1.1.0](https://github.com/toddmotto/fireshell/releases/tag/v1.1.0) (21 September, 2013)
- Add Roadmap and Contributors to `README.md`
- Move `img`, `css`, `js`, `fonts` folders into new `assets` for tidier scaffolding ([#8](https://github.com/toddmotto/fireshell/pull/8))
- Add `grunt-dev.bat` and `grunt-build.bat` for Windows support double-click commands ([#7](https://github.com/toddmotto/fireshell/pull/7))
- Small `Gruntfile.js` tweaks for `assets` object
