### PR TITLE
Change download link from /archive/ to /tag/

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
           FireShell, fiercely quick front-end boilerplate and workflows
         </h1>
         <div class="header__download">
-          <a class="header--btn btn-primary btn--icon" href="//github.com/toddmotto/fireshell/zipball/v1.1.0">
+          <a class="header--btn btn-primary btn--icon" href="//github.com/toddmotto/fireshell/archive/v1.1.0.zip">
             <i class="icon-github"></i>
             Download v1.1.0
           </a><!--


### PR DESCRIPTION
This just pretties up the folder that you receive when downloading from the website.

In the case of a release (v1.1.0 for example), the [`/archive/`](https://github.com/toddmotto/fireshell/archive/v1.1.0.zip) file spits out a nice folder named `fireshell-1.1.0` instead of a folder called `toddmotto-fireshell-2cd313b` that you get from the [`/zipball/`](http://github.com/toddmotto/fireshell/zipball/v1.1.0) link.

This new archive download link comes straight from the [tags/releases](https://github.com/toddmotto/fireshell/releases).

This also makes everyone remember to add a new tag for every release for the download link.

(btw - this change is not the same change that was talked about in issue #18. this is different.)
