### PR TITLE
Install bower components on `npm install`

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "connect-livereload": "~0.2.0",
     "grunt-open": "~0.2.0",
     "matchdep": "~0.1.2"
+  },
+  "scripts": {
+    "postinstall" : "node_modules/.bin/bower install"
   }
 }


### PR DESCRIPTION
There should be some better way to install and/or update bower components with grunt, but this script will install the included bower components on `npm install`.

I tried using grunt-bower-task (https://github.com/yatskevich/grunt-bower-task), but I couldn't get it to work because of its bugs.
