### PR TITLE
Replaced double quotes with single quotes in grunt.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -134,7 +134,7 @@ module.exports = function (grunt) {
      */
     uglify: {
       options: {
-        banner: "<%= tag.banner %>"
+        banner: '<%= tag.banner %>'
       },
       dist: {
         files: {


### PR DESCRIPTION
The [jshint](https://github.com/toddmotto/fireshell/blob/master/.jshintrc) states `"quotmark": "single"`.
