### PR TITLE
livereload mount dir uses project config

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,7 +79,7 @@ module.exports = function (grunt) {
       livereload: {
         options: {
           middleware: function (connect) {
-            return [lrSnippet, mountFolder(connect, 'app')];
+            return [lrSnippet, mountFolder(connect, grunt.config('project.app'))];
           }
         }
       }


### PR DESCRIPTION
Connect/livereload now uses the app value as specified in project config.
