### PR TITLE
add in vendor for box-sizing

### DIFF
--- a/src/scss/modules/_defaults.scss
+++ b/src/scss/modules/_defaults.scss
@@ -1,4 +1,5 @@
 * {
+  -moz-box-sizing: border-box;
   box-sizing: border-box;
   font-smoothing: antialiased;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
this is kinda silly, but firefox still needs the vendor prefix to make box-sizing work in released browsers.

since it's only a single line more of CSS, it probably makes sense to just include this out of the box.
