### PR TITLE
fix style.min.css overwriting

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -287,9 +287,9 @@ module.exports = function (grunt) {
    */
   grunt.registerTask('default', [
     'sass:dev',
-    'cssmin:dev',
     'bower:dev',
     'autoprefixer:dev',
+    'cssmin:dev',
     'jshint',
     'concat:dev',
     'connect:livereload',


### PR DESCRIPTION
`autoprefixer:dev` was running before `cssmin:dev` in the default Grunt task.  
As a result, style.min.css was being overwritten without the cssmin-merged files _(i.e. normalize.css and other components I sometimes add on other FireShell-based projects)_.  

I moved `cssmin:dev` after `autoprefixer:dev` and the missing css is now there.  

I'm not great at Grunt and not fully on top of all of FireShell's changes, so let me know if I'm missing something or if this is valid.
