### PR TITLE
Changed some dependencies to SemVer 2.0(?) versioning syntax…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,9 @@
 {
-  "name": "fireshell",
-  "version": "1.0.0",
-  "dependencies": {
-    "modernizr": "~2.6.2",
-    "jquery": "~1.10.2",
-    "normalize-css": "~2.1.3"
-  }
+	"name": "fireshell",
+	"version": "1.0.0",
+	"dependencies": {
+		"modernizr": "~2.6.2",
+		"jquery": "~1.10.2",
+		"normalize-css": "3.x"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,33 +1,33 @@
 {
-  "name": "fireshell",
-  "title": "Fiercely quick and opinionated front-ends",
-  "url": "http://getfireshell.com",
-  "author": "Todd Motto",
-  "copyright": "2013",
-  "version": "1.1.0",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "http://github.com/toddmotto/fireshell.git"
-  },
-  "devDependencies": {
-    "bower": "~1.2.6",
-    "grunt": "~0.4.1",
-    "grunt-contrib-concat": "~0.3.0",
-    "grunt-contrib-sass": "~0.5.0",
-    "grunt-contrib-uglify": "~0.2.0",
-    "grunt-contrib-connect": "~0.3.0",
-    "grunt-contrib-jshint": "~0.4.3",
-    "grunt-contrib-watch": "~0.4.4",
-    "grunt-bower": "~0.7.0",
-    "grunt-autoprefixer": "~0.3.0",
-    "grunt-contrib-cssmin": "~0.6.2",
-    "grunt-contrib-clean": "~0.5.0",
-    "connect-livereload": "~0.2.0",
-    "grunt-open": "~0.2.0",
-    "matchdep": "~0.1.2"
-  },
-  "scripts": {
-    "postinstall" : "node_modules/.bin/bower install"
-  }
+	"name": "fireshell",
+	"title": "Fiercely quick and opinionated front-ends",
+	"url": "http://getfireshell.com",
+	"author": "Todd Motto",
+	"copyright": "2013",
+	"version": "1.1.0",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "http://github.com/toddmotto/fireshell.git"
+	},
+	"devDependencies": {
+		"bower": "1.x",
+		"grunt": "0.x",
+		"grunt-contrib-concat": "~0.3.0",
+		"grunt-contrib-sass": "~0.5.0",
+		"grunt-contrib-uglify": "~0.2.0",
+		"grunt-contrib-connect": "~0.3.0",
+		"grunt-contrib-jshint": "~0.4.3",
+		"grunt-contrib-watch": "~0.4.4",
+		"grunt-bower": "0.x",
+		"grunt-autoprefixer": "~0.3.0",
+		"grunt-contrib-cssmin": "~0.6.2",
+		"grunt-contrib-clean": "~0.5.0",
+		"connect-livereload": "~0.2.0",
+		"grunt-open": "~0.2.0",
+		"matchdep": "~0.1.2"
+	},
+	"scripts": {
+		"postinstall" : "node_modules/.bin/bower install"
+	}
 }


### PR DESCRIPTION
…to update to the latest build of the newest version (e.g: "bower": "1.x") and fix 'bower install' errors #73  (on Windows 7)